### PR TITLE
structuremsa output mode option between AA and 3di

### DIFF
--- a/src/commons/LocalParameters.cpp
+++ b/src/commons/LocalParameters.cpp
@@ -29,7 +29,8 @@ LocalParameters::LocalParameters() :
         PARAM_GUIDE_TREE(PARAM_GUIDE_TREE_ID, "--guide-tree", "Input Newick guide tree", "Guide tree in Newick format", typeid(std::string), (void *) &guideTree, ".*\\.nw"),
         PARAM_RECOMPUTE_SCORES(PARAM_RECOMPUTE_SCORES_ID, "--recompute-scores", "Recompute scores", "Recompute all-vs-all alignment scores every iteration", typeid(bool), (void *) &recomputeScores, ""),
         PARAM_REGRESSIVE(PARAM_REGRESSIVE_ID, "--regressive", "Regressive alignment", "Align sequences root-to-leaf", typeid(bool), (void *) &regressive, ""),
-        PARAM_PRECLUSTER(PARAM_PRECLUSTER_ID, "--precluster", "Pre-cluster structures", "Pre-cluster structures before constructing MSA", typeid(bool), (void *) &precluster, "")
+        PARAM_PRECLUSTER(PARAM_PRECLUSTER_ID, "--precluster", "Pre-cluster structures", "Pre-cluster structures before constructing MSA", typeid(bool), (void *) &precluster, ""),
+        PARAM_OUTPUT_MODE(PARAM_OUTPUT_MODE_ID, "--output-mode", "Alignment output mode", "Output file mode: \n0: Amino acid\n1: 3Di alphabet", typeid(int), (void *) &outputmode, "[0-1]{1}$")
 {
     PARAM_ALIGNMENT_MODE.description = "How to compute the alignment:\n0: automatic\n1: only score and end_pos\n2: also start_pos and cov\n3: also seq.id";
     PARAM_ALIGNMENT_MODE.regex = "^[0-3]{1}$";
@@ -177,6 +178,7 @@ LocalParameters::LocalParameters() :
     structuremsa.push_back(&PARAM_GUIDE_TREE);
     structuremsa.push_back(&PARAM_RECOMPUTE_SCORES);
     structuremsa.push_back(&PARAM_REGRESSIVE);
+    structuremsa.push_back(&PARAM_OUTPUT_MODE);
     structuremsa.push_back(&PARAM_SUB_MAT);
     structuremsa.push_back(&PARAM_THREADS);
     structuremsa.push_back(&PARAM_MAX_SEQ_LEN);
@@ -198,6 +200,7 @@ LocalParameters::LocalParameters() :
     recomputeScores = false;
     regressive = false;
     precluster = false;
+    outputmode = 0;
 
     // msa2lddt
     msa2lddt.push_back(&PARAM_HELP);

--- a/src/commons/LocalParameters.h
+++ b/src/commons/LocalParameters.h
@@ -61,6 +61,9 @@ public:
 
     static const unsigned int FORMAT_ALIGNMENT_PDB_SUPERPOSED = 5;
 
+    static const int STRUCTUREMSA_OUTPUT_MODE_AA = 0;
+    static const int STRUCTUREMSA_OUTPUT_MODE_3DI = 1;
+
     std::vector<MMseqsParameter *> strucclust;
     std::vector<MMseqsParameter *> tmalign;
     std::vector<MMseqsParameter *> structurealign;
@@ -98,6 +101,7 @@ public:
     PARAMETER(PARAM_RECOMPUTE_SCORES)
     PARAMETER(PARAM_REGRESSIVE)
     PARAMETER(PARAM_PRECLUSTER)
+    PARAMETER(PARAM_OUTPUT_MODE)
 
     // PARAMETER(PARAM_NEWICK_OUTPUT)
     PARAMETER(PARAM_LDDT_HTML)
@@ -117,6 +121,7 @@ public:
     bool recomputeScores;
     bool regressive;
     bool precluster;
+    int outputmode;
     float scoreBiasAa;
     float scoreBias3di;
     MultiParam<PseudoCounts> pcaAa;

--- a/src/strucclustutils/structuremsa.cpp
+++ b/src/strucclustutils/structuremsa.cpp
@@ -1291,7 +1291,8 @@ int structuremsa(int argc, const char **argv, const Command& command, bool preCl
     std::string finalMSA;
     for (size_t i = 0; i < sequenceCnt; ++i) {
         if (msa_aa[i] != "" && msa_3di[i] != "") {
-            finalMSA = msa_aa[i];
+            if (par.outputmode > 0) finalMSA = msa_3di[i];
+            else finalMSA = msa_aa[i];
             ++msaCnt;
             continue;
         }


### PR DESCRIPTION
`structuremsa --output-mode 0` (default) : produces AA alignment file
`structuremsa --output-mode 1` : produces 3Di alignment file